### PR TITLE
add a custom stepper component

### DIFF
--- a/packages/dla-piper/src/components/common/button.js
+++ b/packages/dla-piper/src/components/common/button.js
@@ -3,26 +3,33 @@ import { Button } from "@mui/material";
 import { createTheme, ThemeProvider } from "@mui/material/styles";
 import { theme } from "../common";
 
-const StyledButton = ({ color, filled, fontWeight, fontSize, fixedWidth, minHeight, label }) => {
+const StyledButton = ({ color, filled, fontWeight, fontSize, fixedWidth, minHeight, label, onClick }) => {
     const defaultTheme = createTheme(theme);
+    const handleClick = () => {
+        if (!onClick) {
+            return;
+        }
+        onClick();
+    }
     
     return (
         <ThemeProvider theme={defaultTheme}>
-        <Button
-            color={ color ? color : "primary" }
-            variant={ filled ? "contained" : "text" }
-            sx={{
-                fontWeight: fontWeight ? fontWeight : 400,
-                fontSize: fontSize ? fontSize : "15px",
-                minWidth: fixedWidth ? {
-                    mobile: "100%",
-                    tablet: "288px",
-                } : {},
-                minHeight: minHeight ? minHeight : "44px",
-            }}
-        >
-            {label}
-        </Button>
+            <Button
+                color={ color ? color : "primary" }
+                variant={ filled ? "contained" : "text" }
+                sx={{
+                    fontWeight: fontWeight ? fontWeight : 400,
+                    fontSize: fontSize ? fontSize : "15px",
+                    minWidth: fixedWidth ? {
+                        mobile: "100%",
+                        tablet: "288px",
+                    } : {},
+                    minHeight: minHeight ? minHeight : "44px",
+                }}
+                onClick={handleClick}
+            >
+                {label}
+            </Button>
         </ThemeProvider>
     )
 };

--- a/packages/dla-piper/src/components/common/form/index.js
+++ b/packages/dla-piper/src/components/common/form/index.js
@@ -1,7 +1,12 @@
 import RadioButtonGroup from './radioButtonGroup';
 import DropDownlist from './dropdownlist';
+import ProgressBar from './progressBar';
+import Stepper from './stepper';
 
 export {
     RadioButtonGroup,
     DropDownlist,
-}
+    ProgressBar,
+    Stepper,
+    
+};

--- a/packages/dla-piper/src/components/common/form/progressBar.js
+++ b/packages/dla-piper/src/components/common/form/progressBar.js
@@ -1,0 +1,26 @@
+import { styled } from '@mui/material/styles';
+import { Box } from '@mui/material';
+import LinearProgress, { linearProgressClasses } from '@mui/material/LinearProgress';
+
+const BorderLinearProgress = styled(LinearProgress)(({ theme }) => ({
+  height: 10,
+  borderRadius: 2,
+  [`&.${linearProgressClasses.colorPrimary}`]: {
+    backgroundColor: '#C1C1C1',
+  },
+  [`& .${linearProgressClasses.bar}`]: {
+    borderRadius: 2,
+    backgroundColor: 'buttonColor.main',
+  },
+}));
+
+
+const CustomizedProgressBar = ({ progressPercent }) => {
+  return (
+    <Box sx={{ flexGrow: 1, padding: '10px 0' }}>
+      <BorderLinearProgress variant="determinate" value={progressPercent} />
+    </Box>
+  );
+}
+
+export default CustomizedProgressBar;

--- a/packages/dla-piper/src/components/common/form/stepper.js
+++ b/packages/dla-piper/src/components/common/form/stepper.js
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import { Box, Typography } from '@mui/material';
+import { ProgressBar } from '.';
+import { StyledButton } from '../';
+
+const Stepper = ({ steps=['no steps passed'] }) => {
+  const [currentStep, setCurrentStep] = useState(0);
+  const handleNextStep = () => {
+    setCurrentStep(step => {
+      if (step === steps.length - 1) {
+        return step;
+      }
+      return step + 1;
+    })
+  }
+  const handlePreviousStep = () => {
+    setCurrentStep(step => {
+      if (step === 0) {
+        return step;
+      }
+      return step - 1;
+    })
+  }
+
+  return (
+    <Box 
+      variant='div'
+      sx={{ 
+        padding: '20px',
+        backgroundColor: '#F8F8F8',
+        borderRadius: '4px',
+
+      }}
+    >
+      <Typography variant='p'
+        sx={{
+          fontSize: '14px',
+          color: 'textColor.main',
+
+        }}
+      >
+        Step {currentStep + 1} of {steps.length}
+      </Typography>
+
+      <ProgressBar progressPercent={((100 / (steps.length))) * (currentStep + 1)} />
+      
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', padding: '10px 0' }}>
+        { steps[currentStep] }
+      </Box>
+      
+      <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+        <StyledButton
+          label='Previous'
+          filled
+          onClick={handlePreviousStep}
+        />
+        <StyledButton
+          label='Next'
+          filled
+          onClick={handleNextStep}
+        />
+      </Box>
+    </Box>
+  )
+}
+
+export default Stepper;


### PR DESCRIPTION
Adds a custom Stepper component.

Uses Material UI's `ProgressBar` to display progress and renders whatever is passed into the `steps` prop, this could be a component, text or anything else. 

