### PR TITLE
DLA-60-61: input and text area fields

### DIFF
--- a/packages/dla-piper/src/components/common/form/generateComponentId.js
+++ b/packages/dla-piper/src/components/common/form/generateComponentId.js
@@ -1,0 +1,5 @@
+const generateComponentId = (label, componentType) =>
+  `${label?.replace(/ /g, "-")}-${componentType}`;
+
+
+export default generateComponentId;

--- a/packages/dla-piper/src/components/common/form/index.js
+++ b/packages/dla-piper/src/components/common/form/index.js
@@ -1,9 +1,9 @@
 import RadioButtonGroup from './radioButtonGroup';
 import DropDownlist from './dropdownlist';
-import Input from './input';
+import InputField from './inputField';
 
 export {
     RadioButtonGroup,
     DropDownlist,
-    Input
+    InputField
 }

--- a/packages/dla-piper/src/components/common/form/index.js
+++ b/packages/dla-piper/src/components/common/form/index.js
@@ -1,7 +1,9 @@
 import RadioButtonGroup from './radioButtonGroup';
 import DropDownlist from './dropdownlist';
+import Input from './input';
 
 export {
     RadioButtonGroup,
     DropDownlist,
+    Input
 }

--- a/packages/dla-piper/src/components/common/form/input.js
+++ b/packages/dla-piper/src/components/common/form/input.js
@@ -1,20 +1,41 @@
-import { Box, FormControl, FormLabel, TextField } from "@mui/material";
+import {
+  Typography,
+  Box,
+  FormControl,
+  TextField,
+} from "@mui/material";
+import generateComponentId from "./generateComponentId";
 
-const Input = () => {
+const Input = ({
+  label = "No Label",
+  width = 326,
+  multiline = false,
+  rows = 1,
+}) => {
   return (
     <Box
       component="form"
       sx={{
-        "& > :not(style)": { m: 1, width: "25ch" },
+        m: 1,
+        width,
       }}
-      noValidate
-      autoComplete="off"
     >
       <FormControl fullWidth>
-        <FormLabel>Label</FormLabel>
-        <TextField id="outlined-basic" label="Outlined" variant="outlined" />
-        <TextField id="filled-basic" label="Filled" variant="filled" />
-        <TextField id="standard-basic" label="Standard" variant="standard" />
+        <Typography
+          sx={{
+            fontWeight: "bold",
+            color: "textColor.main",
+          }}
+        >
+          {label}
+        </Typography>
+        <TextField
+          id={generateComponentId(label, "text-field")}
+          name="textField"
+          variant="outlined"
+          multiline={multiline}
+          rows={rows}
+        />
       </FormControl>
     </Box>
   );

--- a/packages/dla-piper/src/components/common/form/input.js
+++ b/packages/dla-piper/src/components/common/form/input.js
@@ -1,0 +1,23 @@
+import { Box, FormControl, FormLabel, TextField } from "@mui/material";
+
+const Input = () => {
+  return (
+    <Box
+      component="form"
+      sx={{
+        "& > :not(style)": { m: 1, width: "25ch" },
+      }}
+      noValidate
+      autoComplete="off"
+    >
+      <FormControl fullWidth>
+        <FormLabel>Label</FormLabel>
+        <TextField id="outlined-basic" label="Outlined" variant="outlined" />
+        <TextField id="filled-basic" label="Filled" variant="filled" />
+        <TextField id="standard-basic" label="Standard" variant="standard" />
+      </FormControl>
+    </Box>
+  );
+};
+
+export default Input;

--- a/packages/dla-piper/src/components/common/form/inputField.js
+++ b/packages/dla-piper/src/components/common/form/inputField.js
@@ -6,7 +6,7 @@ import {
 } from "@mui/material";
 import generateComponentId from "./generateComponentId";
 
-const Input = ({
+const InputField = ({
   label = "No Label",
   width = 326,
   multiline = false,
@@ -41,4 +41,4 @@ const Input = ({
   );
 };
 
-export default Input;
+export default InputField;

--- a/packages/dla-piper/src/components/common/form/radioButtonGroup.js
+++ b/packages/dla-piper/src/components/common/form/radioButtonGroup.js
@@ -3,8 +3,9 @@ import {
   RadioGroup,
   FormControlLabel,
   FormControl,
-  Typography
+  Typography,
 } from "@mui/material";
+import generateComponentId from "./generateComponentId";
 
 const normaliseLabel = (label) => {
   return (
@@ -13,19 +14,20 @@ const normaliseLabel = (label) => {
 };
 
 const RadioButtonsGroup = ({ label = "No Label", options = [] }) => {
-  const id = `${label.replace(/ /g, "-")}-radio-button-group`;
-  
   return (
     <FormControl>
       <Typography
         sx={{
-          fontWeight: 'bold',
+          fontWeight: "bold",
           color: "textColor.main",
         }}
       >
         {normaliseLabel(label)}
       </Typography>
-      <RadioGroup aria-labelledby={id} name="radio-buttons-group">
+      <RadioGroup
+        id={generateComponentId(label, "radio-buttons-group")}
+        name="radio-buttons-group"
+      >
         {options.map((option) => (
           <FormControlLabel
             key={option}

--- a/packages/dla-piper/src/components/common/form/radioButtonGroup.js
+++ b/packages/dla-piper/src/components/common/form/radioButtonGroup.js
@@ -3,21 +3,36 @@ import {
   RadioGroup,
   FormControlLabel,
   FormControl,
-  FormLabel,
+  Typography
 } from "@mui/material";
 
-const RadioButtonsGroup = ({ label = "Radio Button", options = [] }) => {
+const normaliseLabel = (label) => {
+  return (
+    label[0].toUpperCase() + label.slice(1).replace(/-/g, " ").replace("[]", "")
+  );
+};
 
-  const id = `${label.replace(/ /g, '-')}-radio-button-group`;
+const RadioButtonsGroup = ({ label = "No Label", options = [] }) => {
+  const id = `${label.replace(/ /g, "-")}-radio-button-group`;
+  
   return (
     <FormControl>
-      <FormLabel id={id}>{label}</FormLabel>
-      <RadioGroup
-        aria-labelledby={id}
-        name="radio-buttons-group"
+      <Typography
+        sx={{
+          fontWeight: 'bold',
+          color: "textColor.main",
+        }}
       >
+        {normaliseLabel(label)}
+      </Typography>
+      <RadioGroup aria-labelledby={id} name="radio-buttons-group">
         {options.map((option) => (
-          <FormControlLabel key={option} value={option} control={<Radio />} label={option} />
+          <FormControlLabel
+            key={option}
+            value={option}
+            control={<Radio />}
+            label={option}
+          />
         ))}
       </RadioGroup>
     </FormControl>

--- a/packages/dla-piper/src/processors/radioButtonProcessor.js
+++ b/packages/dla-piper/src/processors/radioButtonProcessor.js
@@ -10,15 +10,11 @@ const radioButtonProcessor = {
     );
   },
   processor: ({ node }) => {
-      console.log('node', node)
-    const content = node.children[0].children[0];
-    console.log('content', content)
+    const label = node?.children[1]?.children[0]?.children[0]?.props?.name;
+    const options = node?.children?.map(x => x?.children[0]?.children[0]?.props?.value);
 
     return {
-      props: { 
-          label: "Some label",
-          options: ['test1', 'test2']
-       },
+      props: { label, options },
       component: RadioButtonGroup,
     };
   },


### PR DESCRIPTION
This PR contains changes for the following user stories: 

- [Input field component ](https://anddigitaltransformation.atlassian.net/jira/software/projects/DLA/boards/337?selectedIssue=DLA-60) - Added a new reusable input field component
- [Text area field component](https://anddigitaltransformation.atlassian.net/jira/software/projects/DLA/boards/337?selectedIssue=DLA-61) - Input field component can be turned into a large text area component
- Update radio button group to pull options and label from WP